### PR TITLE
Concat columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+LOCAL*
+
 .gradle
 build/
 

--- a/core/src/main/scala/hydra/spark/dsl/factories/FactoryHelper.scala
+++ b/core/src/main/scala/hydra/spark/dsl/factories/FactoryHelper.scala
@@ -102,6 +102,7 @@ object FactoryHelper {
       val clz: Class[_] = scala.util.Try(m.runtimeClass(c))
         .recover { case e: ClassNotFoundException => classOf[AnyRef] }.get
       val v = clz match {
+        case q if q == classOf[Seq[String]] => cfg.get[List[String]](key).getOrElse(List.empty)
         case q if q == classOf[Map[_, _]] => cfg.get[Map[String, String]](key).getOrElse(Map.empty)
         case q if q == classOf[String] => cfg.getString(key)
         case q if q == classOf[Int] => cfg.getInt(key)

--- a/core/src/main/scala/hydra/spark/operations/transform/ConcatColumns.scala
+++ b/core/src/main/scala/hydra/spark/operations/transform/ConcatColumns.scala
@@ -1,0 +1,23 @@
+package hydra.spark.operations.transform
+
+import hydra.spark.api.{DFOperation, ValidationResult}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+/**
+  * Created by dustinvannoy on 1/20/17.
+  */
+case class ConcatColumns(columnNames: Seq[String], newName: String) extends DFOperation {
+  override def id: String = s"concat-columns-$newName"
+
+  override def transform(df: DataFrame): DataFrame = {
+    import df.sqlContext.implicits.StringToColumn
+    //Define a udf to concatenate two passed in string values
+    val getConcatenated = udf( (col1: String, col2: String) => {col1 + "|" + col2} )
+    df.withColumn(newName, getConcatenated(columnNames.map(c=>$"$c"): _*))
+  }
+
+  override def validate: ValidationResult = {
+    checkRequiredParams(Seq(("columnNames", columnNames), ("newName", newName)))
+  }
+
+}

--- a/core/src/test/scala/hydra/spark/operations/transform/AddColumnSpec.scala
+++ b/core/src/test/scala/hydra/spark/operations/transform/AddColumnSpec.scala
@@ -15,49 +15,33 @@
 
 package hydra.spark.operations.transform
 
-import hydra.spark.testutils.StaticJsonSource
+import hydra.spark.testutils.{SharedSparkContext, StaticJsonSource}
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.{ SparkConf, SparkContext }
-import org.scalatest.{ BeforeAndAfterEach, FunSpecLike, Inside, Matchers }
+import org.apache.spark.sql.{DataFrame, Column}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfterEach, FunSpecLike, Inside, Matchers}
 
 /**
- * Created by alexsilva on 8/12/16.
- */
-class AddColumnSpec extends Matchers with FunSpecLike with Inside with BeforeAndAfterEach {
-
-  val sparkConf = new SparkConf()
-    .setMaster("local")
-    .setAppName("hydra")
-    .set("spark.ui.enabled", "false")
-    .set("spark.local.dir", "/tmp")
-    .set("spark.driver.allowMultipleContexts", "false")
-
-  var sparkCtx: Option[SparkContext] = None
-
-  override def beforeEach() = {
-    sparkCtx = Some(new SparkContext(sparkConf))
-  }
-
-  override def afterEach() = {
-    sparkCtx.foreach(_.stop())
-  }
+  * Created by alexsilva on 8/12/16.
+  */
+class AddColumnSpec extends Matchers with FunSpecLike with SharedSparkContext {
 
   describe("It should add  a column") {
     it("Should add a column") {
-      val sqlContext = new SQLContext(sparkCtx.get)
-      val df = AddColumn("newColum", 10).transform(StaticJsonSource.createDF(sqlContext))
+      val sqlContext = new SQLContext(sc)
+      val df = AddColumn("newColumn", 10).transform(StaticJsonSource.createDF(sqlContext))
       df.first().getInt(3) shouldBe 10
 
-      val df1 = AddColumn("newColum", "new").transform(StaticJsonSource.createDF(sqlContext))
+      val df1 = AddColumn("newColumn", "new").transform(StaticJsonSource.createDF(sqlContext))
       df1.first().getString(3) shouldBe "new"
     }
 
     it("Should add a dynamic column") {
-      val sqlContext = new SQLContext(sparkCtx.get)
-      val df = AddColumn("newColum", "${10+20}").transform(StaticJsonSource.createDF(sqlContext))
+      val sqlContext = new SQLContext(sc)
+      val df = AddColumn("newColumn", "${10+20}").transform(StaticJsonSource.createDF(sqlContext))
       df.first().getInt(3) shouldBe 30
 
-      val df1 = AddColumn("newColum", "${T(java.lang.String).valueOf(1)}")
+      val df1 = AddColumn("newColumn", "${T(java.lang.String).valueOf(1)}")
         .transform(StaticJsonSource.createDF(sqlContext))
       df1.first().getString(3) shouldBe "1"
     }

--- a/core/src/test/scala/hydra/spark/operations/transform/ConcatColumnsSpec.scala
+++ b/core/src/test/scala/hydra/spark/operations/transform/ConcatColumnsSpec.scala
@@ -1,0 +1,19 @@
+package hydra.spark.operations.transform
+
+import hydra.spark.testutils.{SharedSparkContext, StaticJsonSource}
+import org.apache.spark.sql.{SQLContext, DataFrame}
+import org.scalatest.{FunSpecLike, Matchers}
+
+/**
+  * Created by dustinvannoy on 1/20/17.
+  */
+class ConcatColumnsSpec extends Matchers with FunSpecLike with SharedSparkContext {
+
+  describe("It should concatenate two columns") {
+    it("Should allow use of dataframe columns in expressions") {
+      val sqlContext = new SQLContext(sc)
+      val df = ConcatColumns(Seq("email","msg-no"), "newColumn").transform(StaticJsonSource.createDF(sqlContext))
+      df.first().getString(3) shouldBe "alex-silva@ps.com|0"
+    }
+  }
+}

--- a/core/src/test/scala/hydra/spark/operations/transform/ConcatColumnsSpec.scala
+++ b/core/src/test/scala/hydra/spark/operations/transform/ConcatColumnsSpec.scala
@@ -1,7 +1,8 @@
 package hydra.spark.operations.transform
 
+import hydra.spark.dsl.parser.TypesafeDSLParser
 import hydra.spark.testutils.{SharedSparkContext, StaticJsonSource}
-import org.apache.spark.sql.{SQLContext, DataFrame}
+import org.apache.spark.sql.{SQLContext}
 import org.scalatest.{FunSpecLike, Matchers}
 
 /**
@@ -10,10 +11,40 @@ import org.scalatest.{FunSpecLike, Matchers}
 class ConcatColumnsSpec extends Matchers with FunSpecLike with SharedSparkContext {
 
   describe("It should concatenate two columns") {
-    it("Should allow use of dataframe columns in expressions") {
+    it("Should allow use of two dataframe columns to make one column") {
       val sqlContext = new SQLContext(sc)
-      val df = ConcatColumns(Seq("email","msg-no"), "newColumn").transform(StaticJsonSource.createDF(sqlContext))
-      df.first().getString(3) shouldBe "alex-silva@ps.com|0"
+      // ConcatColumns accepts a sequence but dsl will actually send the subtype list
+      val df1 = ConcatColumns(List("email","msg-no"), "newColumn").transform(StaticJsonSource.createDF(sqlContext))
+      df1.first().getString(3) shouldBe "alex-silva@ps.com|0"
     }
+    it("Should be parseable") {
+       val dsl =
+      """
+      |{
+        |    "dispatch": {
+          |        "version": 1,
+          |        "spark.master": "local[*]",
+          |        "name": "test-dispatch",
+          |        "source": {
+          |            "hydra.spark.testutils.ListSource": {
+          |                "messages": ["1", "2", "3"]
+          |            }
+          |        },
+          |        "operations": {
+          |          "concat-columns": {
+          |           "newName": "newCol",
+          |           "columnNames": ["col1", "col2"]
+          |           }
+          |        }
+          |    }
+        |}
+      """.stripMargin
+
+      val dispatch = TypesafeDSLParser().parse(dsl)
+      val d = dispatch.operations.steps.head.asInstanceOf[ConcatColumns]
+      d.columnNames shouldBe Seq("col1","col2")
+      d.newName shouldBe "newCol"
+    }
+
   }
 }


### PR DESCRIPTION
Add tranform to allow concatenating two dataframe fields with a '|' delimiter to form a single column.